### PR TITLE
Use after_cat_bootstrap for DB table creation query

### DIFF
--- a/plugins/chess/chess.py
+++ b/plugins/chess/chess.py
@@ -12,9 +12,7 @@ os.makedirs(DB_DIR, exist_ok=True)
 DB_PATH = os.path.join(DB_DIR, "chess.db")
 
 @hook
-def agent_prompt_prefix(prefix, cat):
-    prefix = """You are a SQL query writer. You can add players to a database and retrieve their stats. If there's a tool output, you must return that output."""
-
+def after_cat_bootstrap(cat):
     # Ensure the directory exists (already handled in Docker configuration)
     # Connect to SQLite database (or create it if it doesn't exist)
     conn = sqlite3.connect(DB_PATH)
@@ -40,6 +38,10 @@ def agent_prompt_prefix(prefix, cat):
     # Commit the changes and close the connection
     conn.commit()
     conn.close()
+
+@hook
+def agent_prompt_prefix(prefix, cat):
+    prefix = """You are a SQL query writer. You can add players to a database and retrieve their stats. If there's a tool output, you must return that output."""
 
     return prefix
 


### PR DESCRIPTION
Nella tua implementazione, la query per l'aggiunta di tabelle al primo avvio veniva eseguita nell'hook `agent_prompt_prefix`, che viene chiamato quasi ad ogni chiamata verso l'LLM, rallentando di molto il plugin.  
Ho spostato quella parte in un altro hook, che viene eseguito solo all'avvio del gatto, lasciando l'altro soltanto per restituire il prompt.

Se invece vorrai passare nel prompt alcuni dati del tuo DB, anche se al momento non dovrebbe servire, ci sarebbero altre possibili soluzioni.